### PR TITLE
米国銘柄を銘柄チェック出来る様にしたい。

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # us_stock_extension
 US Stock Checker for PeakFinder
+
+# 使い方
+1. 拡張機能をダウンロードする
+https://github.com/ogalush/us_stock_extension/archive/refs/heads/main.zip
+→ ダウンロード後、zipファイルを解凍する。
+
+2. 拡張機能を入れる
+```
+Chrome 拡張のインストール方法:
+1. chrome://extensions/ を開く
+2. 画面右上のデベロッパーモードを有効化
+3. 「パッケージ化されていない拡張機能を読み込む」
+4. ダウンロードした「us_stock_extension」フォルダを選択する。
+```
+3. PeakFinderで銘柄を取得する
+4. 「右クリック」→ 「米国銘柄をマーキングする」を押す。
+<img width="235" height="583" alt="image" src="https://github.com/user-attachments/assets/3522218a-0e1d-47cf-9a28-d39012936bd6" />
+
+5. ティッカーコードが黒い太字になるので、マウスポインタを合わせる。
+→ TradingViewの簡易版が表示される。
+<img width="425" height="416" alt="image" src="https://github.com/user-attachments/assets/60d4e819-608c-4903-a4ad-fcfcfbf6bcbb" />
+
+6. TradingViewのiframeのウィンドウを移動させる場合
+→ ウィンドウ上のタイトルバーをドラッグする。
+<img width="680" height="134" alt="image" src="https://github.com/user-attachments/assets/eb542705-97ea-4e26-9e40-72f712401dc1" />
+
+7. TradingViewのiframeのウィンドウの大きさ調整
+→ ウィンドウの右下にポインタを合わせて、ドラッグする。
+<img width="666" height="490" alt="image" src="https://github.com/user-attachments/assets/2687429d-242f-4623-9153-91c2609e2158" />
+
+8. TradingViewのiframeのウィンドウの大きさを閉じる場合
+→ ウィンドウ右上の×を押す

--- a/background.js
+++ b/background.js
@@ -1,0 +1,31 @@
+/*!
+ * Stock Preview Helper
+ * ----------------------------------------
+ * Copyright (c) 2026 Takehiko OGASAWARA
+ * Released under the MIT License
+ *
+ * Description:
+ *  - Hover stock symbol to preview TradingView chart
+ *  - Draggable & resizable preview window
+ *
+ * Author: Takehiko OGASAWARA
+ * Version: 0.1
+ * Last Updated: 2026-01-06
+ */
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: "mark-stocks",
+    title: "米国銘柄をマーキング",
+    contexts: ["page"]
+  });
+});
+
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === "mark-stocks") {
+    chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      files: ["content.js"]
+    });
+  }
+});

--- a/content.js
+++ b/content.js
@@ -1,0 +1,270 @@
+/*!
+ * Stock Preview Helper
+ * ----------------------------------------
+ * Copyright (c) 2026 Takehiko OGASAWARA
+ * Released under the MIT License
+ *
+ * Description:
+ *  - Hover stock symbol to preview TradingView chart
+ *  - Draggable & resizable preview window
+ *
+ * Author: Takehiko OGASAWARA
+ * Version: 0.1
+ * Last Updated: 2026-01-06
+ */
+
+/**************
+ * MarkUp stock-code
+ **************/
+function markDataSymbol() {
+  document.querySelectorAll("tr[data-symbol]").forEach(tr => {
+    const ticker = tr.dataset.symbol;
+    if (!ticker) return;
+
+    const td = tr.querySelector("td");
+    if (!td) return;
+
+    // 二重処理防止
+    if (td.classList.contains("stock-marker")) return;
+
+    td.classList.add("stock-marker");
+    td.dataset.ticker = ticker;
+    td.style.cursor = "text";
+    td.style.backgroundColor = "#fff3b0"; // 薄い黄色
+    td.style.fontWeight = "bold";
+  });
+}
+
+
+/**************
+ * Preview UI (iframe)
+ **************/
+let previewBox = null;
+let previewIframe = null;
+
+function createPreviewBox() {
+  if (previewBox) return;
+
+  previewBox = document.createElement("div");
+  previewBox.id = "stock-preview";
+
+  previewBox.innerHTML = `
+    <div class="header">
+      <span class="title">TradingView (Daily)</span>
+      <button class="close">×</button>
+    </div>
+    <iframe allowfullscreen></iframe>
+    <div class="resize-handle"></div>
+  `;
+
+  document.body.appendChild(previewBox);
+
+  previewIframe = previewBox.querySelector("iframe");
+
+  previewBox.querySelector(".close").onclick = () => {
+    previewBox.remove();
+    previewBox = null;
+    previewIframe = null;
+  };
+
+  enableDrag(previewBox);
+  enableResize(previewBox);
+}
+
+
+/**************
+ * Drag for iframe window
+ **************/
+function enableDrag(box) {
+  const header = box.querySelector(".header");
+  let startX, startY, startLeft, startTop;
+
+  header.addEventListener("mousedown", (e) => {
+    e.preventDefault();
+    startX = e.clientX;
+    startY = e.clientY;
+
+    const rect = box.getBoundingClientRect();
+    startLeft = rect.left;
+    startTop = rect.top;
+
+    document.addEventListener("mousemove", move);
+    document.addEventListener("mouseup", stop);
+  });
+
+  function move(e) {
+    box.style.left = startLeft + (e.clientX - startX) + "px";
+    box.style.top  = startTop  + (e.clientY - startY) + "px";
+  }
+
+  function stop() {
+    document.removeEventListener("mousemove", move);
+    document.removeEventListener("mouseup", stop);
+  }
+}
+
+/**************
+ * Resize for iframe window
+ **************/
+function enableResize(box) {
+  const handle = box.querySelector(".resize-handle");
+  let startX, startY, startW, startH;
+
+  handle.addEventListener("mousedown", (e) => {
+    e.preventDefault();
+    startX = e.clientX;
+    startY = e.clientY;
+
+    const rect = box.getBoundingClientRect();
+    startW = rect.width;
+    startH = rect.height;
+
+    document.addEventListener("mousemove", resize);
+    document.addEventListener("mouseup", stop);
+  });
+
+  function resize(e) {
+    box.style.width  = Math.max(320, startW + (e.clientX - startX)) + "px";
+    box.style.height = Math.max(240, startH + (e.clientY - startY)) + "px";
+  }
+
+  function stop() {
+    document.removeEventListener("mousemove", resize);
+    document.removeEventListener("mouseup", stop);
+  }
+}
+
+
+/**************
+ * Show TradingView iframe
+ **************/
+function showPreview(ticker) {
+  createPreviewBox();
+  previewIframe.src =
+    `https://s.tradingview.com/widgetembed/?symbol=${ticker}&interval=D&hidesidetoolbar=1&hidetoptoolbar=1&theme=light&locale=ja`;
+}
+
+/**************
+ * for copy & Paste stock-codes.
+ **************/
+function getClosestStockMarker(target) {
+  if (target instanceof Element) {
+    return target.closest(".stock-marker");
+  }
+  if (target.parentElement) {
+    return target.parentElement.closest(".stock-marker");
+  }
+  return null;
+}
+
+
+/**************
+ * MouceOver → TradingView iframe
+ **************/
+let hoverTimer = null;
+document.addEventListener("mouseenter", (e) => {
+  const el = getClosestStockMarker(e.target);
+  if (!el) return;
+
+  hoverTimer = setTimeout(() => {
+    showPreview(el.dataset.ticker);
+  }, 300);
+}, true);
+
+/**************
+ * iframe は「選択中は非表示」にする（超重要）
+ **************/
+document.addEventListener("mouseleave", (e) => {
+  const el = getClosestStockMarker(e.target);
+  if (!el) return;
+
+  clearTimeout(hoverTimer);
+}, true);
+
+
+document.addEventListener("selectionchange", () => {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed) {
+    if (previewBox) previewBox.style.display = "flex";
+  } else {
+    if (previewBox) previewBox.style.display = "none";
+  }
+});
+
+/**************
+ * Style
+ **************/
+const style = document.createElement("style");
+style.textContent = `
+#stock-preview {
+  position: fixed;
+  top: 80px;
+  left: 500px;
+  width: 420px;
+  height: 360px;
+  background: #fff;
+  border: 1px solid #ccc;
+  box-shadow: 0 4px 16px rgba(0,0,0,.3);
+  z-index: 999999;
+  display: flex;
+  flex-direction: column;
+  pointer-events: auto;
+}
+
+#stock-preview .header {
+  height: 32px;
+  background: #f5f5f5;
+  cursor: move;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 8px;
+  font-size: 12px;
+  user-select: none;
+}
+
+#stock-preview iframe {
+  flex: 1;
+  border: none;
+}
+
+#stock-preview .close {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+#stock-preview .resize-handle {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 16px;
+  height: 16px;
+  cursor: nwse-resize;
+}
+
+.stock-marker {
+  user-select: text;
+  cursor: text;
+}
+`;
+document.head.appendChild(style);
+
+
+/**************
+ * initialize
+ **************/
+function initMarking() {
+  markDataSymbol();
+}
+
+/**************
+ * Main
+ **************/
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initMarking);
+} else {
+  initMarking();
+}
+

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "米国株版銘柄チェッカー",
+  "version": "0.1",
+  "description": "右クリックで銘柄をマーキング",
+
+  "permissions": [
+    "contextMenus",
+    "scripting",
+    "activeTab"
+  ],
+
+  "background": {
+    "service_worker": "background.js"
+  }
+}


### PR DESCRIPTION
## 目的
PeakFinder 米国版で簡単に状況がわかる様にする。

## 概要
PeakFinder 米国版で 銘柄をざっと確認するChrome拡張が無かったため作成する。

何も無いよりはマシくらいの感じです。

銘柄のマーキング→グラフ表示までは出来たのですが、
その後に銘柄コードをドラッグしてコピペすることがCSSの制約からか何故か出来ないので、そこは制約で。
（1時間ぐらい試しましたが直せず)

## 構成
Google Chrome Extension
JavaScript

## 使い方
1. 拡張機能をダウンロードする
https://github.com/ogalush/us_stock_extension/archive/refs/heads/main.zip
→ ダウンロード後、zipファイルを解凍する。

2. 拡張機能を入れる
```
Chrome 拡張のインストール方法:
1. chrome://extensions/ を開く
2. 画面右上のデベロッパーモードを有効化
3. 「パッケージ化されていない拡張機能を読み込む」を開く。
4. ダウンロードした「us_stock_extension」フォルダを選択する。
5. 拡張機能ウィンドウに「米国株版銘柄チェッカー0.1」が表示されればOK.
```
3. PeakFinderで銘柄を取得する
4. 「右クリック」→ 「米国銘柄をマーキングする」を押す。
<img width="235" height="583" alt="image" src="https://github.com/user-attachments/assets/3522218a-0e1d-47cf-9a28-d39012936bd6" />

5. ティッカーコードが黒い太字になるので、マウスポインタを合わせる。
→ TradingViewの簡易版が表示される。
<img width="425" height="416" alt="image" src="https://github.com/user-attachments/assets/60d4e819-608c-4903-a4ad-fcfcfbf6bcbb" />

6. TradingViewのiframeのウィンドウを移動させる場合
→ ウィンドウ上のタイトルバーをドラッグする。
<img width="680" height="134" alt="image" src="https://github.com/user-attachments/assets/eb542705-97ea-4e26-9e40-72f712401dc1" />

7. TradingViewのiframeのウィンドウの大きさ調整
→ ウィンドウの右下にポインタを合わせて、ドラッグする。
<img width="666" height="490" alt="image" src="https://github.com/user-attachments/assets/2687429d-242f-4623-9153-91c2609e2158" />

8. TradingViewのiframeのウィンドウの大きさを閉じる場合
→ ウィンドウ右上の×を押す