### PR TITLE
Fix: Peakfinderの銘柄コード列 .sticky-col1 Classによる白色上書き対応 (2026.6)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "米国株版銘柄チェッカー",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Cleartradeで利用する銘柄チェッカー。米国株用です。",
   "icons": {
     "16": "icons/icon16.png",

--- a/siteConfigs.js
+++ b/siteConfigs.js
@@ -14,8 +14,12 @@ window.US_STOCK_MARKER.SITE_CONFIGS = [
     target: el => el.querySelector("td"),
     applyStyle: (target) => {
       target.style.color = "#000000"; // 黒色 (ダークモード時に白色 vs 黄色(背景)のため指定)
-      target.style.backgroundColor = "#fff3b0"; // 黄色
       target.style.fontWeight = "bold";
+      target.style.setProperty(
+        "background",
+        "#fff3b0",
+        "important"
+      ); // 黄色 (2026.6.23 Peakfinder .sticky-col1 による色上書き対応)
     }
   },
   {


### PR DESCRIPTION
## 概要
2026.6.23
https://github.com/ogalush/jp_us_stock_extension/pull/11
の横展開版。

2026.6 PeakFinderが改定されたようで、銘柄コード列にCSS `.sticky-col1` Classにより、背景色が白色でimportant指定されていた。
結果として本ツールで銘柄選択した際の背景色黄色の選択が出来ない状態であった。
・変更前の銘柄コード
<img width="288" height="66" alt="image" src="https://github.com/user-attachments/assets/c58fcf82-e3cb-4408-9599-d38692fb35ce" />

・変更前のCSS
<img width="527" height="745" alt="image" src="https://github.com/user-attachments/assets/c6f27efd-0e18-46c3-a1f9-a7ef38760f0b" />





銘柄コードをマーキングするのはユーザ操作であるため、優先させるために `important` 設定をしてoverrideする。


## 効果
想定通り、important上書きで、意図した通り黄色く表示出来た。
・変更後の銘柄コード
<img width="332" height="69" alt="image" src="https://github.com/user-attachments/assets/3e849ec8-daff-48e6-8634-f9c600313f5c" />

・変更後のCSS
<img width="534" height="871" alt="image" src="https://github.com/user-attachments/assets/7b9de57e-7764-4b58-88eb-1e2446caf2ba" />

